### PR TITLE
Fix possible large array index

### DIFF
--- a/diffutils/src/me/xdrop/diffutils/DiffUtils.java
+++ b/diffutils/src/me/xdrop/diffutils/DiffUtils.java
@@ -16,6 +16,9 @@ import java.util.Map;
  * so it is mostly non readable (eg. var names)
  */
 public class DiffUtils {
+    /* Set the maximum size of the integer array for storing the
+       matrix to avoid filling up the heap and result in OOM */
+    public static int MAX_MATRIX_SIZE = 100000;
 
     public static EditOp[] getEditOps(String s1, String s2) {
         return getEditOps(s1.length(), s1, s2.length(), s2);
@@ -58,7 +61,16 @@ public class DiffUtils {
         len1++;
         len2++;
 
-        matrix = new int[len2 * len1];
+        /* Special checking to avoid creating a very large integer array
+           which will up the heap and cause OOM. It also avoid possible
+           negative index because of integer wrap around on the result
+           of large number multiplication. */
+        int matrixSize = len2 * len1;
+        if ((matrixSize > DiffUtils.MAX_MATRIX_SIZE) || (matrixSize <= 0)) {
+            throw new IllegalArgumentException("Provided strings are too long to handle.");
+        }
+
+        matrix = new int[matrixSize];
 
         for (i = 0; i < len2; i++)
             matrix[i] = i;


### PR DESCRIPTION
This fixes a possible OutOfMemory problem and NegativeArraySizeException in diffutils/src/me/xdrop/diffutils/DiffUtils.java.


In the `getEditOps()` method of the DiffUtils class, the length of two strings (after removing matching suffix) are used to create the resulting matrix. The matrix is a 1D array with the size of the multiply of the two string lengths. There are two possible ways that this could go wrong if the two string length is too large. Firstly, if the multiplication result exceeds the `Integer.MAX_VALUE` of java, it will wrap around and stored as a negative number. This makes the creation of the matrix array throws a NegativeArraySizeException. In other cases, if the multiplication result does not exceed the `Integer.MAX_VALUE` of java but exceed the remaining size of the heap storage, it will cause an OutOfMemoryError. Sometimes, it does not need to happen immediately because there may be enough memory to create the big matrix but not enough to allocate for other variables in later operations.


This PR suggests to fix the problem by setting a class variable to define the maximum matrix size allowed. If the multiplication result is larger than the limit or is negative, then just throw an IllegalArgumentException to indicate the two strings are too long to process.


We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated fuzzywuzzy (https://github.com/google/oss-fuzz/pull/10744). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go into detail and also set up things so you can receive emails and detailed reports when bugs are found.
